### PR TITLE
JSON sample causes ambiguity

### DIFF
--- a/WebhookParsing.fs
+++ b/WebhookParsing.fs
@@ -48,7 +48,7 @@ type ClearBankPaymentJson = FSharp.Data.JsonProvider<"""[
         "TimestampCreated": "2019-01-01T11:12:05.101Z",
         "CurrencyCode": "GBP",
         "DebitCreditCode": "Credit",
-        "Reference": "51dcf7ba480e61c5a60bbb6c6b774d17",
+        "Reference": "51dcf7ba480e61c5a60bbb6c6b774d17string",
         "IsReturn": false,
         "Account": {
             "IBAN": "GB00CUBK11223312345678",


### PR DESCRIPTION
The JSON sample for the transaction-settled webhook has a string that is parsable as a GUID and so the type provider interprets it as such, when the [spec](https://clearbank.github.io/docs/webhooks#payments) states that the Reference field is a string. This fix should cause the type provider to interpret it as a string.